### PR TITLE
simplify library

### DIFF
--- a/kromblast.ini
+++ b/kromblast.ini
@@ -1,5 +1,5 @@
 [Kromblast]
-debug=false
+debug=true
 lib="kromlib"
 mode="server"
 path="http://github/Github/Kromblastcpp/test/"

--- a/lib_exemple.cc
+++ b/lib_exemple.cc
@@ -1,64 +1,24 @@
 #include "kromblast_library.h"
-#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-class lib1 : public KromblastLib::KromLib
+
+char *increment(KromblastLib::kromblast_function_called parameters)
 {
-private:
-    int function_number = 1;
-    struct KromblastLib::kromblast_function functions[1] = {
-        {(char*)"libtest.secondexemple.increment", 1}};
+    int nb = atoi(parameters.args[0]);
+    char *result = new char[100];
+    sprintf(result, "{\"count\": %d}", ++nb);
+    return result;
+}
 
-public:
-    struct KromblastLib::kromblast_function *library_callback(int *nb_function)
-    {
-        *nb_function = function_number;
-        return functions;
-    }
+int function_number = 1;
+struct KromblastLib::kromblast_function functions[1] = {
+    {.name = (char *)"libtest.secondexemple.increment",
+     .args_nb = 1,
+     .callback = (KromblastLib::kromblast_function_callback_t)&increment}};
 
-    char *increment(int nb)
-    {
-        char *result = new char[100];
-        sprintf(result, "{\"count\": %d}", ++nb);
-        int len = strlen(result);
-        char *result2 = new char[len + 1];
-        strcpy(result2, result);
-        return result2;
-    }
-
-    char *call_function(struct KromblastLib::kromblast_function_called function_called)
-    {
-        if (strcmp(function_called.name, (char*)functions[0].name) == 0)
-        {
-            int nb = 0;
-            sscanf(function_called.args[0], "%d", &nb);
-            return increment(nb);
-        }
-        return nullptr;
-    }
-
-    bool has_function(const struct KromblastLib::kromblast_function function)
-    {
-        for (int i = 0; i < function_number; i++)
-        {
-            if (strcmp(function.name, functions[i].name) == 0 && function.args_nb == functions[i].args_nb)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    ~lib1()
-    {
-        for (int i = 0; i < function_number; i++)
-        {
-            delete[] functions[i].name;
-        }
-    }
-};
-
-extern "C" KromblastLib::KromLib *create_kromblast_lib()
+extern "C" struct KromblastLib::kromblast_function *get_kromblast_callback(int *nb_function)
 {
-    return new lib1();
+    *nb_function = function_number;
+    return functions;
 }

--- a/libs/kromblast/kromblast.h
+++ b/libs/kromblast/kromblast.h
@@ -23,14 +23,14 @@ namespace Kromblast
     {
         private:
             /**
-             * @brief List of the libraries
+             * @brief List of the callback functions
             */
-            KromblastLib::KromLib **kromblast_lib;
+            KromblastLib::kromblast_function** kromblast_function_lib;
 
             /**
-             * @brief Number of libraries
+             * @brief Number of callback functions
             */
-            int kromblast_lib_nb = -1;
+            int kromblast_function_nb = -1;
 
             /**
              * @brief Webview

--- a/libs/kromblast/lib/kromblast_library.h
+++ b/libs/kromblast/lib/kromblast_library.h
@@ -24,57 +24,26 @@ namespace KromblastLib
     };
 
     /**
+     * @brief Function type for a callback
+    */
+    typedef char* (*kromblast_function_callback_t)(const struct kromblast_function_called);
+
+    /**
      * @brief Structure for simulating a function
      * @property name Function name
      * @property args_nb Arguments number
+     * @property callback Callback of the function
     */
     struct kromblast_function
     {
         char* name;
         int   args_nb;
+        kromblast_function_callback_t callback;
     };
-
+    
     /**
-     * @brief Class of a kromblast library (interface)
-     * @method library_callback Return the list of functions
-     * @method call_function Call a function
-     * @method has_function Check if a function exists in this library
+     * @brief Function type for get all callback of the library
     */
-    class KromLib
-    {
-    public:
-        
-        /**
-         * @brief Return the list of functions
-         * @param nb_function Number of functions in the list
-         * @return Return the list of functions
-        */
-        virtual struct kromblast_function* library_callback(int *nb_function) = 0;
-        
-        /**
-         * @brief Call a function
-         * @param data Data of the function to call
-         * @return Return the result of the function
-        */
-        virtual char *call_function(const struct kromblast_function_called data) = 0;
-        
-        /**
-         * @brief Check if a function exists in this library
-         * @param function_name Name of the function to check
-         * @return Return true if the function exists
-        */
-        virtual bool has_function(const struct kromblast_function) = 0;
-        
-        /**
-         * @brief Destructor
-        */
-        virtual ~KromLib() = default;
-    };
-
-
-    /**
-     * function type for creating a library
-    */
-    typedef KromLib *(*create_lib_t)();
+    typedef struct kromblast_function* (*get_kromblast_callback_t)(int *nb_function);
 }
 #endif


### PR DESCRIPTION
delete class library.
simplify for make only one functions in each library (versus 4 before)
kromblast is the part who redirect the function

